### PR TITLE
clarification usage des .pyxres

### DIFF
--- a/HanselG_main.py
+++ b/HanselG_main.py
@@ -12,7 +12,7 @@ from game import game_init, game_draw, game_update
 
 # initialisation globale
 pyxel.init(128, 128)                   #initialidstaion ecran 
-pyxel.load("res2.pyxres")              # fichier ressources à renommer si besoin
+pyxel.load("res.pyxres")              # fichier ressources à renommer si besoin
 
 ingame = False                          # = on est dans le jeu, donc pas dans le menu
                                         # si besoin on peut remplacer le booleen par une variable à plusieurs valeurs

--- a/game.py
+++ b/game.py
@@ -75,7 +75,7 @@ def game_init():
 
     # intialisations jeu
    
-    perso_x = 60                # position personnage
+    perso_x = 90                # position personnage
     perso_y = 60                # position personnage
     sol = 76                    # hauteur (y) du sol courant (a la position x du personnage+ sa hauteur)
     hauteur_perso = 16          # hauteur affichahge du personnage (toujours = 16)
@@ -111,8 +111,11 @@ def game_init():
                                 # coord X (gauche obstacle)
                                 # type obstacle
     # liste des 6 types d'obstacles et leur tailles: constantes, ne pas toucher
-    # [largeur, hauteur, mortel par contact] à mettre à jour après design des obstacles
-    obst_types = [[8,8,False],[8,10,False],[8,12,False],[8,16,False],[8,15,False],[8,8,False]]
+    # [largeur, hauteur, mortel, posx, posy] à mettre à jour après design des obstacles
+    # largeur / hauteur du dessin
+    # mortel: True/False = c'est un obstacle mortel
+    # posx, posy = position en x,y du haut:gauche dessin dans le fichier pyxres
+    obst_types = [[8,8,False,0,0],[8,10,False,0,0],[3,20,True,0,0],[8,16,False,0,0],[8,15,False,0,0],[8,8,False,0,0]]
 
 #####################################################################################################
 ############### FONCTIONS LOCALES ###################################################################
@@ -241,6 +244,9 @@ def pousse_ou_tue():
                     mort = True
                 else:
                     perso_x -= 1
+                    if perso_x < 0:
+                        mort = True 
+
         
 #========================================================================
 # GESTION DU PERSONNAGE
@@ -384,7 +390,7 @@ def game_draw():
         pyxel.blt(perso_x, perso_y, 0, 0, 48, 13, 16, 2)
         
     else:
-        pyxel.load("res2.pyxres")
+        pyxel.load("res.pyxres")
         # vide la fenetre
         #pyxel.cls(0)
 

--- a/menus.py
+++ b/menus.py
@@ -64,7 +64,7 @@ def affiche_menu(menu):             # affiche les touches de "menu" (tableau)
         # afficher en x_menu+(numero touche * lg-touche), y_menu
         # le dessin situé en 0, ht_touche*code fonction
         # de taille lg_touche sur ht_touche
-        pyxel.blt(x_menu+ind*(lg_touche+separ),y_menu,1,0,ht_touche*menu[ind],lg_touche,ht_touche)
+        pyxel.blt(x_menu+ind*(lg_touche+separ),y_menu,0,0,ht_touche*menu[ind],lg_touche,ht_touche)
 
                                 
 #==================================================================
@@ -147,7 +147,9 @@ def menus_init():
 def menus_draw():
     global menu_touches
 
-    pyxel.cls(0)                    # effacement ecran
+    pyxel.load("menus.pyxres")              # fichier ressources à renommer si besoin
+    pyxel.cls(0)                            # effacement ecran
+
     pyxel.rect(10, 10, 20, 20, 11)
     pyxel.rect(20,20,80,20,12)
     pyxel.text(30, 27, "Hansel & Gretel", 8 )


### PR DESCRIPTION
version ave mort à gauche ou sur obstacle mortel
clarification de l'usage des fichiers pyxres:
res.pyxres = perso+ sorciere + à compléter par plateformes et obstacles.. (menus page 1 ne sont plus utilisés) menus.pyxres = touches menus + trame de fond du jeu res2.pyxres = plus utilisé (c'était une tentative pour un fichier unique)